### PR TITLE
Update dependabot to batch flink dependencies separately

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -11,6 +11,16 @@ updates:
     schedule:
       interval: weekly
     groups:
-      dependencies:
+      flink-dependencies:
+        patterns:
+          - "org.apache.flink:*"
+        group-name: "Flink Dependencies"
+        commit-messages:
+          prefix: "Flink dependencies"
+        update-types: ["security", "version-update:semver-patch"]
+
+      general-dependencies:
         patterns:
           - "*"
+        group-name: "General Dependencies"
+        update-types: ["all"]


### PR DESCRIPTION
Make dependabot to group flink dependencies and general dependencies into separate PRs. Also bump flink dependencies only if there is a security vulnerability and patch release, as I think the minor and major version bumps may need be manual. 