### PR TITLE
Fix dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,15 +12,10 @@ updates:
       interval: weekly
     groups:
       flink-dependencies:
+        applies-to: security-updates
         patterns:
           - "org.apache.flink:*"
-        group-name: "Flink Dependencies"
-        commit-messages:
-          prefix: "Flink dependencies"
-        update-types: ["security", "version-update:semver-patch"]
 
       general-dependencies:
         patterns:
           - "*"
-        group-name: "General Dependencies"
-        update-types: ["all"]


### PR DESCRIPTION
My recent commit has broken the dependabot build due to incorrect syntax. 

Flink dependencies will be updated only if there is a security update. 