### PR TITLE
Fix dependabot group pattern regex

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -14,8 +14,8 @@ updates:
       flink-dependencies:
         applies-to: security-updates
         patterns:
-          - "org.apache.flink:*"
+          - "*flink*"
 
       general-dependencies:
-        patterns:
-          - "*"
+        exclude-patterns:
+          - "*flink*"


### PR DESCRIPTION
Maybe it could be something like `^org\\.apache\\.flink*` but I went with simpler regex to make sure it works. 