### PR TITLE
Add flink-sql-runner-dist and Dockerfile

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -46,19 +46,19 @@ jobs:
         if: github.ref_name != 'main'
         uses: docker/build-push-action@v6
         with:
-          context: flink-sql-runner/
+          context: .
           platforms: linux/amd64,linux/arm64
           push: false
-          file: flink-sql-runner/Dockerfile
+          file: Dockerfile
 
       - name: Build and Push Image
         if: github.event_name == 'push' && github.ref_name == 'main'
         uses: docker/build-push-action@v6
         with:
-          context: flink-sql-runner/
+          context: .
           platforms: linux/amd64,linux/arm64
           push: true
-          file: flink-sql-runner/Dockerfile
+          file: Dockerfile
           tags: ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-sql-runner:latest
 
       ## Save the context information for use in Sonar analysis

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,55 @@
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
+USER 0
+# Install Java and dependencies
+RUN microdnf install -y \
+    wget \
+    hostname \
+    gzip \
+    && microdnf clean all
+
+# Prepare environment
+ENV FLINK_HOME=/opt/flink
+ENV STREAMSHUB_HOME=/opt/streamshub
+ENV FLINK_LIB_DIR=$FLINK_HOME/lib
+ENV FLINK_OPT_DIR=$FLINK_HOME/opt
+ENV PATH=$FLINK_HOME/bin:$PATH
+RUN groupadd --system --gid=9999 flink && \
+    useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
+WORKDIR /opt
+
+COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.0.1-SNAPSHOT-flink-sql-runner-dist.tar.gz flink-sql-runner-dist.tgz
+# Install Flink
+RUN set -ex && \
+  tar -xzf flink-sql-runner-dist.tgz -C /opt --strip-components=1 && \
+  ln -s ${STREAMSHUB_HOME}/flink-sql-runner*.jar ${STREAMSHUB_HOME}/flink-sql-runner.jar && \
+  cp -r ${STREAMSHUB_HOME}/lib/* ${FLINK_HOME}/lib/ && \
+  rm -rf flink-sql-runner-dist.tgz && \
+  chown -R flink:flink $FLINK_HOME && \
+  chown -R flink:flink $STREAMSHUB_HOME && \
+  # Replace default REST/RPC endpoint bind address to use the container's network interface \
+  CONF_FILE="$FLINK_HOME/conf/flink-conf.yaml" && \
+  if [ ! -e "$FLINK_HOME/conf/flink-conf.yaml" ]; then \
+    CONF_FILE="${FLINK_HOME}/conf/config.yaml"; \
+    /bin/bash "$FLINK_HOME/bin/config-parser-utils.sh" "${FLINK_HOME}/conf" "${FLINK_HOME}/bin" "${FLINK_HOME}/lib" \
+        "-repKV" "rest.address,localhost,0.0.0.0" \
+        "-repKV" "rest.bind-address,localhost,0.0.0.0" \
+        "-repKV" "jobmanager.bind-host,localhost,0.0.0.0" \
+        "-repKV" "taskmanager.bind-host,localhost,0.0.0.0" \
+        "-rmKV" "taskmanager.host=localhost"; \
+  else \
+    sed -i 's/rest.address: localhost/rest.address: 0.0.0.0/g' "$CONF_FILE"; \
+    sed -i 's/rest.bind-address: localhost/rest.bind-address: 0.0.0.0/g' "$CONF_FILE"; \
+    sed -i 's/jobmanager.bind-host: localhost/jobmanager.bind-host: 0.0.0.0/g' "$CONF_FILE"; \
+    sed -i 's/taskmanager.bind-host: localhost/taskmanager.bind-host: 0.0.0.0/g' "$CONF_FILE"; \
+    sed -i '/taskmanager.host: localhost/d' "$CONF_FILE"; \
+  fi
+
+# Download the script for docker entrypoint from the GitHub repository and make it executable
+WORKDIR /
+COPY --chown=flink:flink docker-entrypoint.sh /docker-entrypoint.sh
+
+# Configure container
+ENTRYPOINT ["/docker-entrypoint.sh"]
+EXPOSE 6123
+USER flink
+CMD ["help"]

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ An application to execute Flink SQL jobs.
     ```
 2. Build an image
     ```
-    minikube image build flink-sql-runner -t flink-sql-runner:latest
+    minikube image build . -t flink-sql-runner:latest
     ```
 3. Create a `flink` namespace:
    ```

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,190 @@
+#!/usr/bin/env bash
+
+###############################################################################
+#  Licensed to the Apache Software Foundation (ASF) under one
+#  or more contributor license agreements.  See the NOTICE file
+#  distributed with this work for additional information
+#  regarding copyright ownership.  The ASF licenses this file
+#  to you under the Apache License, Version 2.0 (the
+#  "License"); you may not use this file except in compliance
+#  with the License.  You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+#  Unless required by applicable law or agreed to in writing, software
+#  distributed under the License is distributed on an "AS IS" BASIS,
+#  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#  See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+COMMAND_STANDALONE="standalone-job"
+COMMAND_HISTORY_SERVER="history-server"
+
+# If unspecified, the hostname of the container is taken as the JobManager address
+JOB_MANAGER_RPC_ADDRESS=${JOB_MANAGER_RPC_ADDRESS:-$(hostname -f)}
+CONF_FILE_DIR="${FLINK_HOME}/conf"
+
+drop_privs_cmd() {
+    if [ $(id -u) != 0 ]; then
+        # Don't need to drop privs if EUID != 0
+        return
+    elif [ -x /sbin/su-exec ]; then
+        # Alpine
+        echo su-exec flink
+    else
+        # Others
+        echo gosu flink
+    fi
+}
+
+copy_plugins_if_required() {
+  if [ -z "$ENABLE_BUILT_IN_PLUGINS" ]; then
+    return 0
+  fi
+
+  echo "Enabling required built-in plugins"
+  for target_plugin in $(echo "$ENABLE_BUILT_IN_PLUGINS" | tr ';' ' '); do
+    echo "Linking ${target_plugin} to plugin directory"
+    plugin_name=${target_plugin%.jar}
+
+    mkdir -p "${FLINK_HOME}/plugins/${plugin_name}"
+    if [ ! -e "${FLINK_HOME}/opt/${target_plugin}" ]; then
+      echo "Plugin ${target_plugin} does not exist. Exiting."
+      exit 1
+    else
+      ln -fs "${FLINK_HOME}/opt/${target_plugin}" "${FLINK_HOME}/plugins/${plugin_name}"
+      echo "Successfully enabled ${target_plugin}"
+    fi
+  done
+}
+
+set_config_options() {
+    local config_parser_script="$FLINK_HOME/bin/config-parser-utils.sh"
+    local config_dir="$FLINK_HOME/conf"
+    local bin_dir="$FLINK_HOME/bin"
+    local lib_dir="$FLINK_HOME/lib"
+
+    local config_params=()
+
+    while [ $# -gt 0 ]; do
+        local key="$1"
+        local value="$2"
+
+        config_params+=("-D${key}=${value}")
+
+        shift 2
+    done
+
+    if [ "${#config_params[@]}" -gt 0 ]; then
+        "${config_parser_script}" "${config_dir}" "${bin_dir}" "${lib_dir}" "${config_params[@]}"
+    fi
+}
+
+prepare_configuration() {
+    local config_options=()
+
+    config_options+=("jobmanager.rpc.address" "${JOB_MANAGER_RPC_ADDRESS}")
+    config_options+=("blob.server.port" "6124")
+    config_options+=("query.server.port" "6125")
+
+    if [ -n "${TASK_MANAGER_NUMBER_OF_TASK_SLOTS}" ]; then
+        config_options+=("taskmanager.numberOfTaskSlots" "${TASK_MANAGER_NUMBER_OF_TASK_SLOTS}")
+    fi
+
+    if [ ${#config_options[@]} -ne 0 ]; then
+        set_config_options "${config_options[@]}"
+    fi
+
+    if [ -n "${FLINK_PROPERTIES}" ]; then
+        process_flink_properties "${FLINK_PROPERTIES}"
+    fi
+}
+
+process_flink_properties() {
+    local flink_properties_content=$1
+    local config_options=()
+
+    local OLD_IFS="$IFS"
+    IFS=$'\n'
+    for prop in $flink_properties_content; do
+        prop=$(echo $prop | tr -d '[:space:]')
+
+        if [ -z "$prop" ]; then
+            continue
+        fi
+
+        IFS=':' read -r key value <<< "$prop"
+
+        value=$(echo $value | envsubst)
+
+        config_options+=("$key" "$value")
+    done
+    IFS="$OLD_IFS"
+
+    if [ ${#config_options[@]} -ne 0 ]; then
+        set_config_options "${config_options[@]}"
+    fi
+}
+
+maybe_enable_jemalloc() {
+    if [ "${DISABLE_JEMALLOC:-false}" == "false" ]; then
+        JEMALLOC_PATH="/usr/lib/$(uname -m)-linux-gnu/libjemalloc.so"
+        JEMALLOC_FALLBACK="/usr/lib/x86_64-linux-gnu/libjemalloc.so"
+        if [ -f "$JEMALLOC_PATH" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_PATH
+        elif [ -f "$JEMALLOC_FALLBACK" ]; then
+            export LD_PRELOAD=$LD_PRELOAD:$JEMALLOC_FALLBACK
+        else
+            if [ "$JEMALLOC_PATH" = "$JEMALLOC_FALLBACK" ]; then
+                MSG_PATH=$JEMALLOC_PATH
+            else
+                MSG_PATH="$JEMALLOC_PATH and $JEMALLOC_FALLBACK"
+            fi
+            echo "WARNING: attempted to load jemalloc from $MSG_PATH but the library couldn't be found. glibc will be used instead."
+        fi
+    fi
+}
+
+maybe_enable_jemalloc
+
+copy_plugins_if_required
+
+prepare_configuration
+
+args=("$@")
+if [ "$1" = "help" ]; then
+    printf "Usage: $(basename "$0") (jobmanager|${COMMAND_STANDALONE}|taskmanager|${COMMAND_HISTORY_SERVER})\n"
+    printf "    Or $(basename "$0") help\n\n"
+    printf "By default, Flink image adopts jemalloc as default memory allocator. This behavior can be disabled by setting the 'DISABLE_JEMALLOC' environment variable to 'true'.\n"
+    exit 0
+elif [ "$1" = "jobmanager" ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Job Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/jobmanager.sh" start-foreground "${args[@]}"
+elif [ "$1" = ${COMMAND_STANDALONE} ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Job Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/standalone-job.sh" start-foreground "${args[@]}"
+elif [ "$1" = ${COMMAND_HISTORY_SERVER} ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting History Server"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/historyserver.sh" start-foreground "${args[@]}"
+elif [ "$1" = "taskmanager" ]; then
+    args=("${args[@]:1}")
+
+    echo "Starting Task Manager"
+
+    exec $(drop_privs_cmd) "$FLINK_HOME/bin/taskmanager.sh" start-foreground "${args[@]}"
+fi
+
+args=("${args[@]}")
+
+# Running command in pass-through mode
+exec $(drop_privs_cmd) "${args[@]}"

--- a/examples/FlinkDeployment.yaml
+++ b/examples/FlinkDeployment.yaml
@@ -18,7 +18,7 @@ spec:
       memory: "2048m"
       cpu: 1
   job:
-    jarURI: local:///opt/flink/usrlib/flink-sql-runner.jar
+    jarURI: local:///opt/streamshub/flink-sql-runner.jar
     args: ["<SQL_STATEMENTS>"]
     parallelism: 1
     upgradeMode: stateless

--- a/flink-sql-runner-dist/pom.xml
+++ b/flink-sql-runner-dist/pom.xml
@@ -1,0 +1,91 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent>
+        <groupId>com.github.streamshub</groupId>
+        <artifactId>flink-sql</artifactId>
+        <version>0.0.1-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>flink-sql-runner-dist</artifactId>
+
+    <properties>
+        <flink.download.url>
+            https://dlcdn.apache.org/flink/flink-${flink.version}/flink-${flink.version}-bin-scala_2.12.tgz
+        </flink.download.url>
+        <flink.download.sha512>
+            2be32fd038d078c9701f3557d0409b432a5d358749528a8f9113cec119972941b99b8dd375dd4e22e4895a8319b5409533209b3afd5fe73aeaa03566d76f0cc0
+        </flink.download.sha512>
+        <!--by default, tar preserved the uid/gid off the build machine, which can be too long for the RHEL image.
+        9999 matches the image's user/group-->
+        <distribution.override.uid>9999</distribution.override.uid>
+        <distribution.override.gid>9999</distribution.override.gid>
+    </properties>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <artifactId>download-maven-plugin</artifactId>
+                <executions>
+                    <execution>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>wget</goal>
+                        </goals>
+                        <configuration>
+                            <url>${flink.download.url}</url>
+                            <sha512>${flink.download.sha512}</sha512>
+                            <unpack>true</unpack>
+                            <alwaysVerifyChecksum>true</alwaysVerifyChecksum>
+                            <outputDirectory>${project.build.directory}/flink-distribution</outputDirectory>
+                            <!--observed GitHub actions hitting the read timeout even at 20seconds-->
+                            <readTimeOut>60000</readTimeOut>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+            <plugin>
+                <artifactId>maven-assembly-plugin</artifactId>
+                <configuration>
+                    <descriptors>
+                        <descriptor>src/assembly/binary-assembly.xml</descriptor>
+                    </descriptors>
+                    <overrideGid>${distribution.override.gid}</overrideGid>
+                    <overrideUid>${distribution.override.uid}</overrideUid>
+                </configuration>
+                <executions>
+                    <execution>
+                        <id>make-assembly</id>
+                        <phase>package</phase>
+                        <goals>
+                            <goal>single</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+    <dependencies>
+        <!--included in /opt/streamshub/-->
+        <dependency>
+            <groupId>com.github.streamshub</groupId>
+            <artifactId>flink-sql-runner</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <!--included in /opt/streamshub/lib/-->
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-avro-confluent-registry</artifactId>
+            <version>${flink.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.flink</groupId>
+            <artifactId>flink-sql-connector-kafka</artifactId>
+            <version>${flink.kafka.connector.version}</version>
+        </dependency>
+    </dependencies>
+
+</project>

--- a/flink-sql-runner-dist/src/assembly/binary-assembly.xml
+++ b/flink-sql-runner-dist/src/assembly/binary-assembly.xml
@@ -1,0 +1,36 @@
+<assembly xmlns="http://maven.apache.org/ASSEMBLY/2.2.0"
+          xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+          xsi:schemaLocation="http://maven.apache.org/ASSEMBLY/2.2.0 http://maven.apache.org/xsd/assembly-2.2.0.xsd">
+    <id>flink-sql-runner-dist</id>
+    <formats>
+        <!--directory format included to make inspecting the contents easier-->
+        <format>dir</format>
+        <format>tar.gz</format>
+    </formats>
+    <!--to match upstream tarball include a top level directory within the tarball-->
+    <includeBaseDirectory>true</includeBaseDirectory>
+    <fileSets>
+        <fileSet>
+            <directory>${project.build.directory}/flink-distribution/flink-${flink.version}</directory>
+            <outputDirectory>/flink</outputDirectory>
+        </fileSet>
+    </fileSets>
+    <dependencySets>
+        <!--the job is put in its own directory to distinguish it from upstream optional dependencies-->
+        <dependencySet>
+            <outputDirectory>/streamshub/</outputDirectory>
+            <includes>
+                <include>com.github.streamshub:*</include>
+            </includes>
+            <useProjectArtifact>false</useProjectArtifact>
+        </dependencySet>
+        <!--all other dependencies are put in a directory to facilitate adding them all to the flink classpath-->
+        <dependencySet>
+            <outputDirectory>/streamshub/lib</outputDirectory>
+            <excludes>
+                <exclude>com.github.streamshub:*</exclude>
+            </excludes>
+            <useTransitiveDependencies>false</useTransitiveDependencies>
+        </dependencySet>
+    </dependencySets>
+</assembly>

--- a/flink-sql-runner/Dockerfile
+++ b/flink-sql-runner/Dockerfile
@@ -1,4 +1,0 @@
-FROM flink:1.19.1
-
-RUN mkdir /opt/flink/usrlib
-ADD target/flink-sql-runner-*.jar /opt/flink/usrlib/flink-sql-runner.jar

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -59,19 +59,6 @@
         </dependency>
 
         <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-avro-confluent-registry</artifactId>
-            <version>${flink.avro.confluent.registry.version}</version>
-        </dependency>
-
-        <!-- Connectors -->
-        <dependency>
-            <groupId>org.apache.flink</groupId>
-            <artifactId>flink-connector-kafka</artifactId>
-            <version>${flink.kafka.connector.version}</version>
-        </dependency>
-
-        <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter</artifactId>
             <version>${jupiter.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,8 @@
 
     <!-- Maven plugin versions -->
     <maven.compiler.version>3.13.0</maven.compiler.version>
+    <maven.assembly.version>3.7.1</maven.assembly.version>
+    <maven.download.version>1.9.0</maven.download.version>
 
     <!-- Project dependency version -->
     <flink.version>1.19.1</flink.version>
@@ -34,6 +36,7 @@
 
   <modules>
       <module>flink-sql-runner</module>
+      <module>flink-sql-runner-dist</module>
   </modules>
 
   <build>
@@ -43,6 +46,16 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-compiler-plugin</artifactId>
           <version>${maven.compiler.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>com.googlecode.maven-download-plugin</groupId>
+          <artifactId>download-maven-plugin</artifactId>
+          <version>${maven.download.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-assembly-plugin</artifactId>
+          <version>${maven.assembly.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
- **Add flink-sql-runner dist**
Produces a flink-sql-runner-dist tarball containing:
```
.
└── flink-sql-runner-dist-0.0.1-SNAPSHOT
    ├── flink
     .... flink 1.19.1 distribution
    └── streamshub
        ├── flink-sql-runner-0.0.1-SNAPSHOT.jar
        └── lib
            ├── flink-sql-avro-confluent-registry-1.19.1.jar
            └── flink-sql-connector-kafka-3.2.0-1.19.jar
```

- **Install distribution into docker image**
Dockerfile produces an image similar to the upstream flink 1.19 image, based on RHEL with:
1. `streamshub/lib` jars from the distribution copied into `/opt/flink/lib`
2. `streamshub` dir from the distribution copied to `/opt/streamshub`
3. a symlink /opt/streamshub/flink-sql-runner.jar is created to the job jar so we have a stable name FlinkDeployments can refer to.

- **Remove connector/format from fat jar**