### PR TITLE
Reduce image size by using a staged build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,14 @@
+FROM registry.access.redhat.com/ubi9/ubi:9.4 AS stage
+WORKDIR /opt
+COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.0.1-SNAPSHOT-flink-sql-runner-dist.tar.gz flink-sql-runner-dist.tgz
+RUN tar -xzf flink-sql-runner-dist.tgz -C /opt --strip-components=1
+
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
 USER 0
 # Install Java and dependencies
 RUN microdnf install -y \
     wget \
     hostname \
-    gzip \
     && microdnf clean all
 
 # Prepare environment
@@ -17,10 +21,10 @@ RUN groupadd --system --gid=9999 flink && \
     useradd --system --home-dir $FLINK_HOME --uid=9999 --gid=flink flink
 WORKDIR /opt
 
-COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.0.1-SNAPSHOT-flink-sql-runner-dist.tar.gz flink-sql-runner-dist.tgz
+COPY --from=stage --chown=flink:flink /opt/flink/ /opt/flink/
+COPY --from=stage --chown=flink:flink /opt/streamshub/ /opt/streamshub/
 # Install Flink
 RUN set -ex && \
-  tar -xzf flink-sql-runner-dist.tgz -C /opt --strip-components=1 && \
   ln -s ${STREAMSHUB_HOME}/flink-sql-runner*.jar ${STREAMSHUB_HOME}/flink-sql-runner.jar && \
   cp -r ${STREAMSHUB_HOME}/lib/* ${FLINK_HOME}/lib/ && \
   rm -rf flink-sql-runner-dist.tgz && \


### PR DESCRIPTION
This way we do not have a layer containing the 500M tarball followed by a layer containing the 500MB of extracted contents. The tarball is only copied to an intermediate build image.
