### PR TITLE
Fix the parsing issue with sasl.jaas.config

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,8 +28,14 @@ An application to execute Flink SQL jobs.
    ```
    {{secret:<NAMESPACE>/<SECRET NAME>/<DATA KEY>}}
    ```
-   If running with the local image built in step 2, ensure that the FlinkDeployment's image is updated. 
+   If running with the local image built in step 2, ensure that the FlinkDeployment's image is updated.
 8. Start a Flink job:
    ```
    kubectl create example/FlinkDeployment.yaml -n flink
+   ```
+   Update `example/FlinkDeployment.yaml` with your own SQL statements e.g. `args: ["<SQL_STATEMENTS>"]`. 
+   Note that semicolon `;` is a special character used as a statement delimiter. If it's part of your SQL statements, make sure it is escaped by `\\`. 
+   For example, it might be used for `properties.sasl.jaas.config` value when using Kafka connector. In this case, it would look something like this:
+   ```
+   'properties.sasl.jaas.config' = 'org.apache.flink.kafka.shaded.org.apache.kafka.common.security.plain.PlainLoginModule required username=\"test-user\" password=\"{{secret:flink/test-user/user.password}}\"\\;'
    ```

--- a/examples/FlinkDeployment.yaml
+++ b/examples/FlinkDeployment.yaml
@@ -19,6 +19,7 @@ spec:
       cpu: 1
   job:
     jarURI: local:///opt/streamshub/flink-sql-runner.jar
-    args: ["<SQL_STATEMENTS>"]
+    #Replace the value for "args" with your own SQL statements
+    args: ["CREATE TABLE orders (order_number BIGINT, price DECIMAL(32,2), buyer ROW<first_name STRING, last_name STRING>, last_name STRING, order_time TIMESTAMP(3)) WITH ('connector' = 'datagen'); CREATE TABLE print_table WITH ('connector' = 'print') LIKE orders; INSERT INTO print_table SELECT * FROM orders;"]
     parallelism: 1
     upgradeMode: stateless

--- a/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
+++ b/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
@@ -89,8 +89,14 @@ public class SqlRunner {
             otherStatements = formatted.replace(statementSet, "").trim();
         }
 
+        boolean escaped = false;
         for (char c : otherStatements.toCharArray()) {
-            if (c == STATEMENT_DELIMITER.charAt(0)) {
+            if (escaped) {
+                current.append(c);
+                escaped = false;
+            } else if (c == '\\') {
+                escaped = true;
+            } else if (c == STATEMENT_DELIMITER.charAt(0)) {
                 current.append(c);
                 statements.add(current.toString().trim());
                 current = new StringBuilder();

--- a/flink-sql-runner/src/test/java/com/github/streamshub/flink/SqlRunnerTest.java
+++ b/flink-sql-runner/src/test/java/com/github/streamshub/flink/SqlRunnerTest.java
@@ -44,7 +44,7 @@ class SqlRunnerTest {
                         "'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9093', " +
                         "'properties.security.protocol' = 'SASL_PLAINTEXT', " +
                         "'properties.sasl.mechanism' = 'PLAIN', " +
-                        "'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username={{secret:flink/mysecret/username}} password={{secret:flink/mysecret/password}}'); " +
+                        "'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{secret:flink/mysecret/username}}\" password=\"{{secret:flink/mysecret/password}}\"\\;'); " +
                 "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print'); " +
                 "INSERT INTO print_table SELECT * FROM Table1; ";
 
@@ -54,7 +54,7 @@ class SqlRunnerTest {
                         "'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9093', " +
                         "'properties.security.protocol' = 'SASL_PLAINTEXT', " +
                         "'properties.sasl.mechanism' = 'PLAIN', " +
-                        "'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username={{secret:flink/mysecret/username}} password={{secret:flink/mysecret/password}}');",
+                        "'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{secret:flink/mysecret/username}}\" password=\"{{secret:flink/mysecret/password}}\";');",
                 "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print');",
                 "INSERT INTO print_table SELECT * FROM Table1;");
 


### PR DESCRIPTION
- Update README doc with an example of configuring jaas config correctly when using Kafka Connector.
- Update the test with a more realistic jaar config to make sure semi colon is parsed correctly. 
- Add a basic SQL statements to the FlinkDeployment example so that a user does not need to come up with one themselves if they just want to try running Flink. 