### PR TITLE
Add log4j2 based logging

### DIFF
--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -45,11 +45,30 @@
             <version>${flink.version}</version>
             <scope>provided</scope>
         </dependency>
+
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-api</artifactId>
             <version>${slf4j.version}</version>
             <scope>provided</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-api</artifactId>
+            <version>${log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-core</artifactId>
+            <version>${log4j.version}</version>
+            <scope>runtime</scope>
+        </dependency>
+        <dependency>
+            <groupId>org.apache.logging.log4j</groupId>
+            <artifactId>log4j-slf4j2-impl</artifactId>
+            <version>${log4j.version}</version>
+            <scope>runtime</scope>
         </dependency>
 
         <dependency>

--- a/flink-sql-runner/src/main/resources/log4j2.properties
+++ b/flink-sql-runner/src/main/resources/log4j2.properties
@@ -1,0 +1,11 @@
+name = SQLRunnerConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+rootLogger.level = ${env:FLINK_SQL_RUNNER_LOG_LEVEL:-INFO}
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false

--- a/flink-sql-runner/src/test/java/com/github/streamshub/flink/SqlRunnerTest.java
+++ b/flink-sql-runner/src/test/java/com/github/streamshub/flink/SqlRunnerTest.java
@@ -1,6 +1,7 @@
 package com.github.streamshub.flink;
 
 import java.util.List;
+
 import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -9,6 +10,7 @@ class SqlRunnerTest {
 
     @Test
     void testParseStatements() {
+
         String statements = "CREATE TABLE Table1 ( field STRING, field1 STRING ) WITH ( 'connector' = 'datagen'); " +
                 "CREATE TABLE Table2 WITH ( 'connector' = 'print') LIKE Table1; " +
                 "INSERT INTO Table2 SELECT * FROM Table1;";

--- a/flink-sql-runner/src/test/resources/log4j2.properties
+++ b/flink-sql-runner/src/test/resources/log4j2.properties
@@ -1,0 +1,11 @@
+name = SQLRunnerConfig
+
+appender.console.type = Console
+appender.console.name = STDOUT
+appender.console.layout.type = PatternLayout
+appender.console.layout.pattern = %d{yyyy-MM-dd HH:mm:ss} %-5p %c{1}:%L - %m%n
+
+rootLogger.level = ${env:FLINK_SQL_RUNNER_LOG_LEVEL:-DEBUG}
+rootLogger.appenderRefs = stdout
+rootLogger.appenderRef.console.ref = STDOUT
+rootLogger.additivity = false

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <flink.version>1.19.1</flink.version>
     <kafka.version>3.7.0</kafka.version>
     <slf4j.version>2.0.16</slf4j.version>
+    <log4j.version>2.24.1</log4j.version>
     <fabric8.kubernetes-client.version>6.13.4</fabric8.kubernetes-client.version>
     <flink.avro.confluent.registry.version>1.19.1</flink.avro.confluent.registry.version>
     <flink.kafka.connector.version>3.2.0-1.19</flink.kafka.connector.version>


### PR DESCRIPTION
This PR adds Log4j2 based logging to the SQL Runner. 

The log level can be tuned by setting the `FLINK_SQL_RUNNER_LOG_LEVEL` env var in the pod.