### PR TITLE
Add the maven surefire plugin

### DIFF
--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -76,6 +76,7 @@ jobs:
           name: target
           path: |
             **/target/
-            !**/target/*.jar
+            !flink-sql-runner-dist/**
+            !**/target/**.jar
             !**/target/failsafe-reports/**/*
             !**/target/surefire-reports/**/*

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -123,36 +123,35 @@
 
     <profiles>
         <profile>
-        <id>coverage</id>
-        <build>
-        <plugins>
-            <plugin>
-            <groupId>org.jacoco</groupId>
-            <artifactId>jacoco-maven-plugin</artifactId>
-            <version>${jacoco.version}</version>
-            <executions>
-                <execution>
-                    <id>prepare-agent</id>
-                    <goals>
-                        <goal>prepare-agent</goal>
-                    </goals>
-                </execution>
-                <execution>
-                    <id>report</id>
-                    <goals>
-                        <goal>report</goal>
-                    </goals>
-                    <configuration>
-                        <formats>
-                            <format>XML</format>
-                        </formats>
-                    </configuration>
-                </execution>
-            </executions>
-            </plugin>
-        </plugins>
-        </build>
+            <id>coverage</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.jacoco</groupId>
+                        <artifactId>jacoco-maven-plugin</artifactId>
+                        <version>${jacoco.version}</version>
+                        <executions>
+                            <execution>
+                                <id>prepare-agent</id>
+                                <goals>
+                                    <goal>prepare-agent</goal>
+                                </goals>
+                            </execution>
+                            <execution>
+                                <id>report</id>
+                                <goals>
+                                    <goal>report</goal>
+                                </goals>
+                                <configuration>
+                                    <formats>
+                                        <format>XML</format>
+                                    </formats>
+                                </configuration>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
         </profile>
     </profiles>
-
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -17,6 +17,7 @@
     <maven.compiler.version>3.13.0</maven.compiler.version>
     <maven.assembly.version>3.7.1</maven.assembly.version>
     <maven.download.version>1.10.0</maven.download.version>
+    <maven.surefire.version>3.5.1</maven.surefire.version>
     <jacoco.version>0.8.12</jacoco.version>
 
     <!-- Project dependency version -->
@@ -57,6 +58,11 @@
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-assembly-plugin</artifactId>
           <version>${maven.assembly.version}</version>
+        </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-surefire-plugin</artifactId>
+          <version>${maven.surefire.version}</version>
         </plugin>
       </plugins>
     </pluginManagement>


### PR DESCRIPTION
This PR adds the maven surefire plugin so that tests run properly for the coverage report generation, needed for sonar cloud.

This also removes the flink-sql-runner-dist from the shipped build artifacts from the integration GH Action. 
The dist consists of code (flink and the sql runner) that is already checked by other processes so doesn't need to be shipped for checking again.