### PR TITLE
Refactor runner arg parsing for mulit-entry and multi-line

### DIFF
--- a/examples/FlinkDeployment.yaml
+++ b/examples/FlinkDeployment.yaml
@@ -20,6 +20,21 @@ spec:
   job:
     jarURI: local:///opt/streamshub/flink-sql-runner.jar
     #Replace the value for "args" with your own SQL statements
-    args: ["CREATE TABLE orders (order_number BIGINT, price DECIMAL(32,2), buyer ROW<first_name STRING, last_name STRING>, last_name STRING, order_time TIMESTAMP(3)) WITH ('connector' = 'datagen'); CREATE TABLE print_table WITH ('connector' = 'print') LIKE orders; INSERT INTO print_table SELECT * FROM orders;"]
+    args:
+      - |
+        CREATE TABLE orders (
+          order_number BIGINT, 
+          price DECIMAL(32,2), 
+          buyer ROW<first_name STRING, last_name STRING>, 
+          last_name STRING, order_time TIMESTAMP(3)
+        ) WITH (
+          'connector' = 'datagen'
+        );
+      - |
+        CREATE TABLE print_table 
+        WITH (
+          'connector' = 'print'
+        ) LIKE orders;
+      - INSERT INTO print_table SELECT * FROM orders;
     parallelism: 1
     upgradeMode: stateless

--- a/flink-sql-runner/src/test/java/com/github/streamshub/flink/SqlRunnerTest.java
+++ b/flink-sql-runner/src/test/java/com/github/streamshub/flink/SqlRunnerTest.java
@@ -9,23 +9,27 @@ import static org.junit.jupiter.api.Assertions.*;
 class SqlRunnerTest {
 
     @Test
-    void testParseStatements() {
+    void testParseStatementArgs() {
 
-        String statements = "CREATE TABLE Table1 ( field STRING, field1 STRING ) WITH ( 'connector' = 'datagen'); " +
-                "CREATE TABLE Table2 WITH ( 'connector' = 'print') LIKE Table1; " +
-                "INSERT INTO Table2 SELECT * FROM Table1;";
+        String statement1 = "CREATE TABLE Table1 (\n\tfield STRING,\n\tfield1 STRING\n) WITH (\n\t'connector' = 'datagen'\n); " +
+                "CREATE TABLE Table2 WITH ( 'connector' = 'print') LIKE Table1; ";
+        String statement2 = "'INSERT INTO Table2 SELECT * FROM Table1; '";
+        String statement3 = "\"SELECT * FROM multilinestatement\nWHERE\n\tthisThing > thatThing\n\tAND\n\tname != that;\"";
+
+        String [] statements = new String[]{statement1, statement2, statement3};
 
         List<String> expected = List.of(
-                "CREATE TABLE Table1 ( field STRING, field1 STRING ) WITH ( 'connector' = 'datagen');",
+                "CREATE TABLE Table1 ( field STRING, field1 STRING ) WITH ( 'connector' = 'datagen' );",
                 "CREATE TABLE Table2 WITH ( 'connector' = 'print') LIKE Table1;",
-                "INSERT INTO Table2 SELECT * FROM Table1;");
+                "INSERT INTO Table2 SELECT * FROM Table1;",
+                "SELECT * FROM multilinestatement WHERE thisThing > thatThing AND name != that;");
 
-        List<String> actual = SqlRunner.parseStatements(statements);
+        List<String> actual = SqlRunner.parseStatementArgs(statements);
         assertEquals(expected, actual);
     }
 
     @Test
-    void testParseStatementsTrailingSemiColon() {
+    void testParseStatementArgsTrailingSemiColon() {
         String statements = "CREATE TABLE Table1 ( field STRING, field1 STRING ) WITH ( 'connector' = 'datagen'); " +
                 "CREATE TABLE Table2 WITH ( 'connector' = 'print') LIKE Table1; " +
                 "INSERT INTO Table2 SELECT * FROM Table1";
@@ -35,20 +39,20 @@ class SqlRunnerTest {
                 "CREATE TABLE Table2 WITH ( 'connector' = 'print') LIKE Table1;",
                 "INSERT INTO Table2 SELECT * FROM Table1;");
 
-        List<String> actual = SqlRunner.parseStatements(statements);
+        List<String> actual = SqlRunner.parseStatementArgs(new String[]{statements});
         assertEquals(expected, actual);
     }
 
     @Test
-    void testParseStatementsWithSecrets () {
-        String statements = "CREATE TABLE Table1 ( message STRING ) WITH ( 'connector' = 'kafka', " +
-                        "'topic' = 'test', " +
-                        "'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9093', " +
-                        "'properties.security.protocol' = 'SASL_PLAINTEXT', " +
-                        "'properties.sasl.mechanism' = 'PLAIN', " +
-                        "'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{secret:flink/mysecret/username}}\" password=\"{{secret:flink/mysecret/password}}\"\\;'); " +
-                "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print'); " +
-                "INSERT INTO print_table SELECT * FROM Table1; ";
+    void testParseStatementArgsWithSecrets() {
+        String statements = "CREATE TABLE Table1 (\nmessage STRING\n) WITH (\n\t'connector' = 'kafka',\n" +
+                        "\t'topic' = 'test',\n" +
+                        "\t'properties.bootstrap.servers' = 'my-cluster-kafka-bootstrap.flink.svc:9093',\n" +
+                        "\t'properties.security.protocol' = 'SASL_PLAINTEXT',\n" +
+                        "\t'properties.sasl.mechanism' = 'PLAIN',\n" +
+                        "\t'properties.sasl.jaas.config' = 'org.apache.kafka.common.security.plain.PlainLoginModule required username=\"{{secret:flink/mysecret/username}}\" password=\"{{secret:flink/mysecret/password}}\"\\;');\n" +
+                "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print');\n" +
+                "INSERT INTO print_table SELECT * FROM Table1;\n";
 
         List<String> expected = List.of(
                 "CREATE TABLE Table1 ( message STRING ) WITH ( 'connector' = 'kafka', " +
@@ -60,7 +64,7 @@ class SqlRunnerTest {
                 "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print');",
                 "INSERT INTO print_table SELECT * FROM Table1;");
 
-        List<String> actual = SqlRunner.parseStatements(statements);
+        List<String> actual = SqlRunner.parseStatementArgs(new String[]{statements});
         assertEquals(expected, actual);
 
     }
@@ -68,30 +72,32 @@ class SqlRunnerTest {
     @Test
     void testParseStatementSet() {
         String statementSet =
-                "CREATE TABLE KafkaTable ( message STRING ) WITH ('connector' = 'kafka'" +
-                        "  'topic' = 'user_behavior'," +
-                        "  'properties.bootstrap.servers' = 'localhost:9092'," +
-                        "  'properties.group.id' = 'testGroup'," +
-                        "  'scan.startup.mode' = 'earliest-offset'," +
-                        "  'format' = 'csv'); " +
-                "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print'); " +
-                "CREATE TABLE print_table2 ( message STRING ) WITH ('connector' = 'print'); " +
-                "EXECUTE STATEMENT SET BEGIN INSERT INTO print_table SELECT * FROM KafkaTable; " +
-                "INSERT INTO print_table2 SELECT * FROM print_table; END; ";
+                "CREATE TABLE KafkaTable (\nmessage STRING\n) WITH (\n'connector' = 'kafka'\n" +
+                        "\t'topic' = 'user_behavior',\n" +
+                        "\t'properties.bootstrap.servers' = 'localhost:9092',\n" +
+                        "\t'properties.group.id' = 'testGroup',\n" +
+                        "\t'scan.startup.mode' = 'earliest-offset',\n" +
+                        "\t'format' = 'csv'\n);\n" +
+                "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print');\n" +
+                "CREATE TABLE print_table2 ( message STRING ) WITH ('connector' = 'print');\n" +
+                "EXECUTE STATEMENT SET\nBEGIN\n\tINSERT INTO print_table SELECT * FROM KafkaTable;\n" +
+                "\tINSERT INTO print_table2 SELECT * FROM print_table;\nEND;\n" +
+                "SELECT *\nFROM print_table2;";
 
         List<String> expected = List.of(
-                "CREATE TABLE KafkaTable ( message STRING ) WITH ('connector' = 'kafka'" +
-                        "  'topic' = 'user_behavior'," +
-                        "  'properties.bootstrap.servers' = 'localhost:9092'," +
-                        "  'properties.group.id' = 'testGroup'," +
-                        "  'scan.startup.mode' = 'earliest-offset'," +
-                        "  'format' = 'csv');",
+                "CREATE TABLE KafkaTable ( message STRING ) WITH ( 'connector' = 'kafka' " +
+                        "'topic' = 'user_behavior', " +
+                        "'properties.bootstrap.servers' = 'localhost:9092', " +
+                        "'properties.group.id' = 'testGroup', " +
+                        "'scan.startup.mode' = 'earliest-offset', " +
+                        "'format' = 'csv' );",
                 "CREATE TABLE print_table ( message STRING ) WITH ('connector' = 'print');",
                 "CREATE TABLE print_table2 ( message STRING ) WITH ('connector' = 'print');",
                 "EXECUTE STATEMENT SET BEGIN INSERT INTO print_table SELECT * FROM KafkaTable; " +
-                "INSERT INTO print_table2 SELECT * FROM print_table; END;");
+                "INSERT INTO print_table2 SELECT * FROM print_table; END;",
+                "SELECT * FROM print_table2;");
 
-        List<String> actual = SqlRunner.parseStatements(statementSet);
+        List<String> actual = SqlRunner.parseStatementArgs(new String[]{statementSet});
         assertEquals(expected, actual);
     }
 }


### PR DESCRIPTION
This PR changes the handling of the args supplied to the SQLRunner main method so that it will:
* Allow SQL statements to be passed as a list (not one single long string)
* Allow each SQL statement passed to be multi-line and tabbed for easy readability
* Change the Statement Set handling so that sets remain in order and are not moved to the end

This means that instead of a using:

```yaml
  job:
    jarURI: local:///opt/streamshub/flink-sql-runner.jar
    args: ["Long string with multiple SQL statements in;"]
```
 we can now do:
```yaml
  job:
    jarURI: local:///opt/streamshub/flink-sql-runner.jar
    args:
      - |
        CREATE TABLE orders (
          order_number BIGINT, 
          price DECIMAL(32,2), 
          buyer ROW<first_name STRING, last_name STRING>, 
          last_name STRING, order_time TIMESTAMP(3)
        ) WITH (
          'connector' = 'datagen'
        );
      - |
        CREATE TABLE print_table 
        WITH (
          'connector' = 'print'
        ) LIKE orders;
      - INSERT INTO print_table SELECT * FROM orders;
 ```

This is a backwards compatible change and the long string array method will still work. 

This PR also changes the handling of [Statement Sets](https://docs.confluent.io/cloud/current/flink/reference/queries/statement-set.html) to match the example from the upstream Flink Kubernetes Operator example. Previously we would assume only 1 such statement set would be supplied and we would move it to the end of the statements list. It is possible there could be multiple statement sets and that later queries depend on the results created by them, so this PR changes the processing so that they remain in order.

This parsing is likely to need to be checked using more comprehensive system tests in [streams-e2e](https://github.com/streamshub/streams-e2e) which I will add once this PR has been reviewed.