### PR TITLE
Release 0.0.1

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 FROM registry.access.redhat.com/ubi9/ubi:9.4 AS stage
 WORKDIR /opt
-COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.0.1-SNAPSHOT.tar.gz flink-sql-runner-dist.tgz
+COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.0.1.tar.gz flink-sql-runner-dist.tgz
 RUN tar -xzf flink-sql-runner-dist.tgz -C /opt --strip-components=1
 
 FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20

--- a/flink-sql-runner-dist/pom.xml
+++ b/flink-sql-runner-dist/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.streamshub</groupId>
         <artifactId>flink-sql</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.1</version>
     </parent>
 
     <artifactId>flink-sql-runner-dist</artifactId>

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.streamshub</groupId>
         <artifactId>flink-sql</artifactId>
-        <version>0.0.1-SNAPSHOT</version>
+        <version>0.0.1</version>
     </parent>
 
     <artifactId>flink-sql-runner</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.streamshub</groupId>
   <artifactId>flink-sql</artifactId>
-  <version>0.0.1-SNAPSHOT</version>
+  <version>0.0.1</version>
   <packaging>pom</packaging>
 
   <properties>


### PR DESCRIPTION
Before we move on to Flink 1.20 it would be good to get a tagged version that depends on 1.19