### PR TITLE
Add temporary action to manually build and push tagged docker image for v0.0.1

### DIFF
--- a/.github/workflows/manual-image-build.yaml
+++ b/.github/workflows/manual-image-build.yaml
@@ -1,0 +1,64 @@
+name: Manual Build
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to build'     
+        required: true
+        default: 'v0.0.1'
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.tag }}
+
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build with Maven
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: mvn -B clean verify -Pcoverage
+
+      - name: Login to Quay
+        uses: docker/login-action@v3
+        with:
+          registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
+          username: "${{ secrets.IMAGE_REPO_USERNAME }}"
+          password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
+
+      - name: Image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            quay.io/streamshub/flink-sql-runner
+          tags: |
+            type=raw,value=${{github.event.inputs.tag}}
+
+      - name: Build and Push Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          file: Dockerfile
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}


### PR DESCRIPTION
Why:
We've got an v0.0.1 tag we'd like an image built for since our automation didn't handle it when we tagged it.

Tested on my [fork](https://github.com/robobario/flink-sql/actions/runs/11585204482/job/32253740801) which produced a [v0.0.1 tagged image](https://quay.io/repository/robeyoun/flink-sql-runner?tab=tags) to my personal flink-sql-runner quay repository.

I'm also wondering if we need to make the `integration.yaml` workflow triggered on tag push, at the moment it's only main branch push. It's possible that main is pushed before it's tagged, see https://github.com/docker/metadata-action?tab=readme-ov-file#typeref