### PR TITLE
Add the util-linux package to the image build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -9,6 +9,7 @@ USER 0
 RUN microdnf install -y \
     wget \
     hostname \
+    util-linux \
     && microdnf clean all
 
 # Prepare environment


### PR DESCRIPTION
This PR adds the `util-linux` package to the image build. This provides the `rev` command which is needed by the Flink [config.sh](https://github.com/apache/flink/blob/e19f576358221172d6ef7837a320e1557f19c45b/flink-dist/src/main/flink-bin/bin/config.sh#L287) script to parse any Java specification options.

This command is needed for the config script to complete successfully. 