### PR TITLE
Change from jre17 to jre11 in the image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ WORKDIR /opt
 COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.1.0-SNAPSHOT.tar.gz flink-sql-runner-dist.tgz
 RUN tar -xzf flink-sql-runner-dist.tgz -C /opt --strip-components=1
 
-FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-11-runtime:1.20
 USER 0
 # Install Java and dependencies
 RUN microdnf install -y \


### PR DESCRIPTION
## Description

Set to Draft pending agreement about how we want to solve this.

The flink operator currently targets java11 based images by default and if we provide a java17 based image then the operator or user has to supply some add-opens parameters to the java command. To avoid the user having to configure this esoteric and verbose set of opts in every FlinkDeployment we will target 11 for now.

The dream was to prepare for Flink 2.0+ where originally it was planned to make java17 the default, but that appears to have dropped out of the 2.0 release. So using the same JRE as upstream is going to make our lives easier.

Note we still build with JDK17 but target 11 as the release for the job jar, so it's compatible.


## Type of Change

* New feature (non-breaking change which adds functionality)

## Testing
Packit test job with smoke subset of tests is triggered by default.
If you want to run full flink test profile please type a following comment
```
/packit test --labels flink-all
```
