### PR TITLE
Add release workflow

### DIFF
--- a/.github/scripts/setVersions.sh
+++ b/.github/scripts/setVersions.sh
@@ -1,0 +1,9 @@
+#!/bin/bash
+# usage: setVersions.sh pomVersion
+
+if [[ $# != 1 ]]; then
+    echo "Illegal number of parameters" >&2
+    exit 1
+fi
+mvn -B versions:set -DgenerateBackupPoms=false -DnewVersion=${1}
+sed --in-place --regexp-extended "s|flink-sql-runner-dist-([^[:space:]]*)\.tar.gz|flink-sql-runner-dist-${1}.tar.gz|g" Dockerfile

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,7 +2,8 @@ name: Build
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "releases/**" ]
+    tags: [ "v*" ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 
@@ -35,7 +36,7 @@ jobs:
         run: mvn -B clean verify -Pcoverage
 
       - name: Test Image Build
-        if: github.ref_name != 'main'
+        if: github.event_name == 'pull_request'
         uses: docker/build-push-action@v6
         with:
           context: .
@@ -44,7 +45,7 @@ jobs:
           file: Dockerfile
 
       - name: Login to Quay
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         uses: docker/login-action@v3
         with:
           registry: "${{ secrets.IMAGE_REPO_HOSTNAME }}"
@@ -52,15 +53,22 @@ jobs:
           password: "${{ secrets.IMAGE_REPO_PASSWORD }}"
 
       - name: Image metadata
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            quay.io/streamshub/flink-sql-runner
+            ${{ secrets.IMAGE_REPO_HOSTNAME }}/${{ secrets.IMAGE_REPO_NAMESPACE }}/flink-sql-runner
+          tags: |
+            type=ref,event=branch
+            type=ref,event=tag
+          flavor: |
+            latest=false
+            prefix=
+            suffix=
 
       - name: Build and Push Image
-        if: github.event_name == 'push' && github.ref_name == 'main'
+        if: github.event_name == 'push'
         uses: docker/build-push-action@v6
         with:
           context: .

--- a/.github/workflows/integration.yaml
+++ b/.github/workflows/integration.yaml
@@ -2,8 +2,8 @@ name: Build
 
 on:
   push:
-    branches: [ "main", "releases/**" ]
-    tags: [ "v*" ]
+    branches: [ "main", "releases-**" ]
+    tags: [ "[0-9]+.[0-9]+.[0-9]+" ]
   pull_request:
     types: [ opened, synchronize, reopened ]
 

--- a/.github/workflows/release-transition.yaml
+++ b/.github/workflows/release-transition.yaml
@@ -1,0 +1,60 @@
+name: Create Release Transition PR
+on:
+  workflow_dispatch:
+    inputs:
+      branch:
+        description: 'Branch to transition'
+        required: false
+        default: 'main'
+      newVersion:
+        description: 'New Version'
+        required: true
+        default: '0.0.1-SNAPSHOT'
+      transition:
+        type: choice
+        description: Choose
+        options:
+        - DEVELOPMENT_TO_RELEASE
+        - RELEASE_TO_DEVELOPMENT
+jobs:
+  create-transition-pr:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.inputs.branch }}
+      - name: Set up Java
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: maven
+      - name: Update Sources
+        run: |
+          .github/scripts/setVersions.sh "${{ github.event.inputs.newVersion }}"
+      - name: Test maven build
+        run: mvn -B clean verify
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        id: buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Test Build Image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: false
+          file: Dockerfile
+      - name: Create Pull Request
+        uses: peter-evans/create-pull-request@v7
+        with:
+          # use token so that the created PR will trigger other actions, default GITHUB_TOKEN does not do this
+          token: ${{ secrets.RELEASE_PAT }}
+          commit-message: "Update to ${{ github.event.inputs.newVersion }}"
+          branch: "release-transition-${{ github.event.inputs.branch }}-${{ github.event.inputs.newVersion }}"
+          signoff: true
+          title: "Release Transition ${{ github.event.inputs.branch }} from ${{ github.event.inputs.transition }}: ${{github.event.inputs.newVersion}}"
+          body: "Release Transition ${{ github.event.inputs.branch }} from ${{ github.event.inputs.transition }}: ${{github.event.inputs.newVersion}}"
+          labels: release

--- a/.github/workflows/release-transition.yaml
+++ b/.github/workflows/release-transition.yaml
@@ -51,7 +51,7 @@ jobs:
         uses: peter-evans/create-pull-request@v7
         with:
           # use token so that the created PR will trigger other actions, default GITHUB_TOKEN does not do this
-          token: ${{ secrets.RELEASE_PAT }}
+          token: ${{ secrets.RELEASE_TOKEN }}
           commit-message: "Update to ${{ github.event.inputs.newVersion }}"
           branch: "release-transition-${{ github.event.inputs.branch }}-${{ github.event.inputs.newVersion }}"
           signoff: true

--- a/README.md
+++ b/README.md
@@ -53,3 +53,7 @@ We welcome your contributions to the Flink SQL project! To ensure a smooth colla
 * **Code Quality**: Your code must pass SonarCloud code analysis checks.
 * **Unit Tests**: Update existing unit tests for any modifications and write new tests for new features.
 * **System Tests**: Repository developers can trigger [Packit CI](tmt/README.md/#packit-as-a-service-for-pr-check) for running system tests.
+
+## Releasing
+
+Follow the [Releasing](RELEASING.md) guide.

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,6 +1,6 @@
 # Releasing
 
-Currently the only external artefact for a release is the SQL runner image in quay.io
+Currently the only external artefact for a release is the SQL runner image in quay.io.
 
 The automation builds and pushes images to quay on push to:
 1. main (image will be tagged as main eg quay.io/streamshub/flink-sql-runner:main )

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -4,8 +4,8 @@ Currently the only external artefact for a release is the SQL runner image in qu
 
 The automation builds and pushes images to quay on push to:
 1. main (image will be tagged as main eg quay.io/streamshub/flink-sql-runner:main )
-2. branches named releases/** (image will be tagged as branch name eg releases/0.0 will be tagged at quay.io/streamshub/flink-sql-runner:releases-0.0)
-3. tag push (image will be tagged with the git tag, for example git tag v0.0.1 -> quay.io/streamshub/flink-sql-runner:v0.0.1)
+2. branches named release-** (image will be tagged as branch name eg release-0.0 will be tagged at quay.io/streamshub/flink-sql-runner:release-0.0)
+3. semver-like tag push (image will be tagged with the git tag, for example git tag 0.0.1 -> quay.io/streamshub/flink-sql-runner:0.0.1)
 
 For the branches targeted above we can use github Actions to transition them between two states:
 
@@ -24,25 +24,27 @@ The repository must have a `RELEASE_PAT` secret containing a non-expired GitHub 
   - New Version: if your development branch is on 0.0.1-SNAPSHOT in the maven projects, you would set this to 0.0.1
   - Choose: `DEVELOPMENT_TO_RELEASE`
 2. This will create a PR. After CI has run against this PR, review, approve and merge it.
-3. Fetch the branch changes locally and tag the merge commit as `v${version}`. So if you are releasing 0.0.1, run `git tag -a v0.0.1 -m v0.0.1` and push the tag up.
-4. This tag push will trigger [integration.yaml](https://github.com/streamshub/flink-sql/actions/workflows/integration.yaml) to push a v0.0.1 tagged image to quay.io,
+3. Fetch the branch changes locally and tag the merge commit as `${version}`. So if you are releasing `0.0.1`, run `git tag -a 0.0.1 -m 0.0.1` and push the tag up.
+4. This tag push will trigger [integration.yaml](https://github.com/streamshub/flink-sql/actions/workflows/integration.yaml) to push a `0.0.1` tagged image to quay.io,
   matching the references in the deployment YAML that were set in the transition PR.
 
 ## To Transition a Branch back to Development after Release
 
 1. Run the [Create Release Transition PR workflow](https://github.com/streamshub/flink-sql/actions/workflows/release-transition.yaml) setting:
   - Branch to transition: the branch you want to release (typically main)
-  - New Version: the next development version, so if you released 0.0.1 this might now be 0.1.0-SNAPSHOT
+  - New Version: the next development version, so if you released 0.0.1 this might now be 0.0.2-SNAPSHOT
   - Choose: `RELEASE_TO_DEVELOPMENT`
 2. This will create a PR. After CI has run against this PR, review, approve and merge it.
+3. The branch will now have the pom versions set to your new version (like 0.0.2-SNAPSHOT)
 
 ## Working with Backports/Bugfixes
 
 If we ever needed to release an older version for some reason (like we wanted to put out a bugfixed 0.0.2 but main has moved far ahead)
 
-1. Branch off the tag you want to work from, the release branch name must start with `releases/`, so if I want to add a bugfix to 0.0.1 I might
-  execute `git checkout -b releases/0.0 v0.0.1 && git push releases/0.0`
-2. Transition the new `releases/0.0` branch to Development following the process above,  setting the branch to `releases/0.0` in the action
+1. Branch off the tag you want to work from, the release branch name must start with `release-`. So if we discovered a bug in 0.0.1 and wanted
+to release a new 0.0.2 containing the bugfix, we could run  `git branch -b release-0.0.2 0.0.1` and push `release-0.0.2` to github.
+2. Transition the new `release-0.0.2` branch to Development following the process above,  setting the branch to `release-0.0.2` in the action
+and the new version to 1.0.2-SNAPSHOT
 3. Make code changes
-4. Release the branch following the process above, setting the branch to `releases/0.0` in the action
-
+4. Release the branch following the process above, setting the branch to `release-0.0.2` in the action and new version `0.0.2`
+5. As above, tag the latest commit in `release-0.0.2` as `0.0.2` and push it up. The automation will produce an image tagged 0.0.2 in quay.io

--- a/RELEASING.md
+++ b/RELEASING.md
@@ -1,0 +1,48 @@
+# Releasing
+
+Currently the only external artefact for a release is the SQL runner image in quay.io
+
+The automation builds and pushes images to quay on push to:
+1. main (image will be tagged as main eg quay.io/streamshub/flink-sql-runner:main )
+2. branches named releases/** (image will be tagged as branch name eg releases/0.0 will be tagged at quay.io/streamshub/flink-sql-runner:releases-0.0)
+3. tag push (image will be tagged with the git tag, for example git tag v0.0.1 -> quay.io/streamshub/flink-sql-runner:v0.0.1)
+
+For the branches targeted above we can use github Actions to transition them between two states:
+
+1. Snapshot, where the maven versions are SNAPSHOT and the image references in the deployments use the branch name as image tag.
+2. Release, where the maven version are non-SNAPSHOT and the image references in the deployments point at a tagged image.
+
+## Prerequisites
+You must have permissions to execute manual GitHub Actions workflows and the ability to push tags to this repository
+
+The repository must have a `RELEASE_PAT` secret containing a non-expired GitHub Personal Access Token with write permissions for this repositories contents and PRs.
+
+## To Release a Branch that is in Development
+
+1. Run the [Create Release Transition PR workflow](https://github.com/streamshub/flink-sql/actions/workflows/release-transition.yaml) setting:
+  - Branch to transition: the branch you want to release (typically main)
+  - New Version: if your development branch is on 0.0.1-SNAPSHOT in the maven projects, you would set this to 0.0.1
+  - Choose: `DEVELOPMENT_TO_RELEASE`
+2. This will create a PR. After CI has run against this PR, review, approve and merge it.
+3. Fetch the branch changes locally and tag the merge commit as `v${version}`. So if you are releasing 0.0.1, run `git tag -a v0.0.1 -m v0.0.1` and push the tag up.
+4. This tag push will trigger [integration.yaml](https://github.com/streamshub/flink-sql/actions/workflows/integration.yaml) to push a v0.0.1 tagged image to quay.io,
+  matching the references in the deployment YAML that were set in the transition PR.
+
+## To Transition a Branch back to Development after Release
+
+1. Run the [Create Release Transition PR workflow](https://github.com/streamshub/flink-sql/actions/workflows/release-transition.yaml) setting:
+  - Branch to transition: the branch you want to release (typically main)
+  - New Version: the next development version, so if you released 0.0.1 this might now be 0.1.0-SNAPSHOT
+  - Choose: `RELEASE_TO_DEVELOPMENT`
+2. This will create a PR. After CI has run against this PR, review, approve and merge it.
+
+## Working with Backports/Bugfixes
+
+If we ever needed to release an older version for some reason (like we wanted to put out a bugfixed 0.0.2 but main has moved far ahead)
+
+1. Branch off the tag you want to work from, the release branch name must start with `releases/`, so if I want to add a bugfix to 0.0.1 I might
+  execute `git checkout -b releases/0.0 v0.0.1 && git push releases/0.0`
+2. Transition the new `releases/0.0` branch to Development following the process above,  setting the branch to `releases/0.0` in the action
+3. Make code changes
+4. Release the branch following the process above, setting the branch to `releases/0.0` in the action
+


### PR DESCRIPTION
## Description

This adds a workflow that can create a PR transitioning a branch from in development to release, or vice versa. A releaser:

1. executes the manual action to create a PR updating the maven versions
2. merges this PR after CI runs
3. manually tags and pushes up the release tag, triggering creation of a tagged image
4. executes the transition action to create a PR updating the branch for development
5. merges this PR

Images will be created on every push to main and branches named `release-**`. The image will be tagged with the branch name.

Images will be created when any tag matching `[0-9]+.[0-9]+.[0-9]+` is pushed. The image will be tagged with the git tag.

Nothing is tagged as latest currently.

## Concrete Example of releasing main

1. main is in development, the pom.xml's and Dockerfile contain version 0.0.1-SNAPSHOT
2. releaser runs the `Create Release Transition PR` Action with settings:
   ```
   Branch to transition: main
   New Version: 0.0.1
   Choose: DEVELOPMENT_TO_RELEASE
   ```
3. A PR is created called `Release Transition main from DEVELOPMENT_TO_RELEASE: 0.0.1`
4. Wait for CI to run then merge the PR. Now the pom.xmls and Dockerfile on main are configured with version 0.0.1.
6. On your local machine, fetch the changes and tag the latest commit in `main` as `0.0.1`. `git tag -a 0.0.1 -m 0.0.1` and push the tag up.
7. A GitHub action will build and push an image to quay.io tagged with `0.0.1`
8. releaser runs the `Create Release Transition PR` Action with settings:
   ```
   Branch to transition: main
   New Version: 0.0.2-SNAPSHOT
   Choose: RELEASE_TO_DEVELOPMENT
   ```
9. A PR is created called `Release Transition main from RELEASE_TO_DEVELOPMENT: 0.0.2-SNAPSHOT`
10. Wait for CI to run then merge the PR. Now the pom.xmls and Dockerfile on main are configured with version 0.0.2-SNAPSHOT.
11. Development can resume

## Release Branches and Backporting

It is designed to be run against `main` for the most part but if we need to start backporting fixes to older versions then you can:
1. branch off an existing tag with `git clone -b release-0.0.2 0.0.1 && git push release-0.0.2`. 
2. use the action to transition that `release-0.0.2` branch from release to snapshot with version 0.0.2-SNAPSHOT.
5. make your code changes, merging PRs to release-0.0.2.
8. use the action to transition `release-0.0.2` from snapshot to release with version 0.0.2.
9. pull down the changes and tag the latest commit in release-0.0.2 as `0.0.2` and push the tag up. This will prompt integration.yaml to release the flink-sql-runner image tagged as 0.0.2

## Type of Change

* New feature (non-breaking change which adds functionality)

## Testing
Packit test job with smoke subset of tests is triggered by default.
If you want to run full flink test profile please type a following comment
```
/packit test --labels flink-all
```
