### PR TITLE
Update to Flink 1.20.1

### DIFF
--- a/flink-sql-runner-dist/pom.xml
+++ b/flink-sql-runner-dist/pom.xml
@@ -17,7 +17,7 @@
             https://dlcdn.apache.org/flink/flink-${flink.version}/flink-${flink.version}-bin-scala_2.12.tgz
         </flink.download.url>
         <flink.download.sha512>
-           2af8c4d0329df8b139d8ad50ef9179bfed98907a9df7d4411b6e60ff60ca8105f81d07d8d2b7b904e214e68f10c9dfa3616274ca692a2b18de66f3541597a71d 
+            c50105a095839c663074d6a242e72d0e27886f584e0d568a89e3cf84b87da2b5cf188e230f65890a4622192ddad49b347d57ea5fe1c3510d27484b64a4b4c415
         </flink.download.sha512>
         <!--by default, tar preserved the uid/gid off the build machine, which can be too long for the RHEL image.
         9999 matches the image's user/group-->
@@ -28,8 +28,9 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>com.googlecode.maven-download-plugin</groupId>
+                <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
+                <version>${maven.download.version}</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>flink-sql-runner</artifactId>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
+        <maven.compiler.release>17</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencyManagement>

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -12,7 +12,7 @@
     <artifactId>flink-sql-runner</artifactId>
 
     <properties>
-        <maven.compiler.release>17</maven.compiler.release>
+        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
     <dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -16,22 +16,22 @@
     <!-- Maven plugin versions -->
     <maven.compiler.version>3.13.0</maven.compiler.version>
     <maven.assembly.version>3.7.1</maven.assembly.version>
-    <maven.download.version>1.11.1</maven.download.version>
-    <maven.surefire.version>3.5.1</maven.surefire.version>
+    <maven.download.version>2.0.0</maven.download.version>
+    <maven.surefire.version>3.5.2</maven.surefire.version>
     <jacoco.version>0.8.12</jacoco.version>
 
     <!-- Project dependency version -->
-    <flink.version>1.20.0</flink.version>
-    <kafka.version>3.7.0</kafka.version>
+    <flink.version>1.20.1</flink.version>
+    <kafka.version>3.9.0</kafka.version>
     <slf4j.version>2.0.16</slf4j.version>
-    <log4j.version>2.24.1</log4j.version>
-    <fabric8.kubernetes-client.version>6.13.4</fabric8.kubernetes-client.version>
+    <log4j.version>2.24.3</log4j.version>
+    <fabric8.kubernetes-client.version>7.1.0</fabric8.kubernetes-client.version>
     <flink.avro.confluent.registry.version>1.20.0</flink.avro.confluent.registry.version>
-    <flink.kafka.connector.version>3.3.0-1.20</flink.kafka.connector.version>
+    <flink.kafka.connector.version>3.4.0-1.20</flink.kafka.connector.version>
 
     <!-- Test only dependencies -->
-    <mockito.version>5.14.2</mockito.version>
-    <jupiter.version>5.11.3</jupiter.version>
+    <mockito.version>5.15.2</mockito.version>
+    <jupiter.version>5.11.4</jupiter.version>
     <!-- Sonar settings -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>streamshub</sonar.organization>

--- a/pom.xml
+++ b/pom.xml
@@ -25,7 +25,7 @@
     <kafka.version>3.9.0</kafka.version>
     <slf4j.version>2.0.16</slf4j.version>
     <log4j.version>2.24.3</log4j.version>
-    <fabric8.kubernetes-client.version>7.1.0</fabric8.kubernetes-client.version>
+    <fabric8.kubernetes-client.version>6.13.5</fabric8.kubernetes-client.version>
     <flink.avro.confluent.registry.version>1.20.0</flink.avro.confluent.registry.version>
     <flink.kafka.connector.version>3.4.0-1.20</flink.kafka.connector.version>
 


### PR DESCRIPTION
## Description

Updates the Flink version to the newly released 1.20.1.

This also updates several dependencies and maven plugins to their latest versions.

## Type of Change

* Update 

## Testing

```
/packit test --labels flink-all
```
