### PR TITLE
Upgrade to Flink 2.0.0 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,9 @@
-FROM registry.access.redhat.com/ubi9/ubi:9.4 AS stage
+FROM registry.access.redhat.com/ubi9/ubi:9.5 AS stage
 WORKDIR /opt
-COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.1.1-SNAPSHOT.tar.gz flink-sql-runner-dist.tgz
+COPY flink-sql-runner-dist/target/flink-sql-runner-dist-0.2.0-SNAPSHOT.tar.gz flink-sql-runner-dist.tgz
 RUN tar -xzf flink-sql-runner-dist.tgz -C /opt --strip-components=1
 
-FROM registry.access.redhat.com/ubi9/openjdk-11-runtime:1.20
+FROM registry.access.redhat.com/ubi9/openjdk-17-runtime:1.22
 USER 0
 # Install Java and dependencies
 RUN microdnf install -y \

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ _Note_: Refer to the instructions `docs/installation.adoc` to install the Flink 
     ```
     minikube image build . -t flink-sql-runner:latest
     ```
-4. Create a `FlinkDeployment` custom resource that references the image you just built (`flink-sql-runner:latest`).
+4. Create a `FlinkDeployment` custom resource that references the image you just built (`flink-sql-runner:latest`) and set the `imagePullPolicy` to `Never`.
 5. Apply the `FlinkDeployment` to the `flink` namespace. This namespace has the RBAC setup (via helm) to run Flink Job. If you want to run in another namespace then apply the `install/flink-namespace-rbac.yaml` to the chosen namespace.   
 
 ## Building the documentation

--- a/flink-sql-runner-dist/pom.xml
+++ b/flink-sql-runner-dist/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.streamshub</groupId>
         <artifactId>flink-sql</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-sql-runner-dist</artifactId>
@@ -17,7 +17,7 @@
             https://dlcdn.apache.org/flink/flink-${flink.version}/flink-${flink.version}-bin-scala_2.12.tgz
         </flink.download.url>
         <flink.download.sha512>
-            c50105a095839c663074d6a242e72d0e27886f584e0d568a89e3cf84b87da2b5cf188e230f65890a4622192ddad49b347d57ea5fe1c3510d27484b64a4b4c415
+            0edeb57f9bc263faa6b817f783596e0370d11c7b2dd9e9bf8ab42b13f6bc55e026e6ba56415252e8a8c3d2b038313453968618dbf72b2391e0a6b54de41354bc
         </flink.download.sha512>
         <!--by default, tar preserved the uid/gid off the build machine, which can be too long for the RHEL image.
         9999 matches the image's user/group-->
@@ -30,7 +30,7 @@
             <plugin>
                 <groupId>io.github.download-maven-plugin</groupId>
                 <artifactId>download-maven-plugin</artifactId>
-                <version>${maven.download.version}</version>
+                <version>${download.maven.version}</version>
                 <executions>
                     <execution>
                         <phase>process-resources</phase>
@@ -58,6 +58,7 @@
                     </descriptors>
                     <overrideGid>${distribution.override.gid}</overrideGid>
                     <overrideUid>${distribution.override.uid}</overrideUid>
+                    <tarLongFileMode>posix</tarLongFileMode>
                 </configuration>
                 <executions>
                     <execution>

--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -6,7 +6,7 @@
     <parent>
         <groupId>com.github.streamshub</groupId>
         <artifactId>flink-sql</artifactId>
-        <version>0.1.1-SNAPSHOT</version>
+        <version>0.2.0-SNAPSHOT</version>
     </parent>
 
     <artifactId>flink-sql-runner</artifactId>
@@ -121,9 +121,15 @@
                                     Otherwise, this might cause SecurityExceptions when using the JAR. -->
                                     <artifact>*:*</artifact>
                                     <excludes>
+                                        <exclude>module-info.class</exclude>
+                                        <exclude>META-INF/*.idx</exclude>
+                                        <exclude>META-INF/*.MF</exclude>
                                         <exclude>META-INF/*.SF</exclude>
                                         <exclude>META-INF/*.DSA</exclude>
                                         <exclude>META-INF/*.RSA</exclude>
+                                        <exclude>META-INF/LICENSE</exclude>
+                                        <exclude>META-INF/NOTICE</exclude>
+                                        <exclude>META-INF/DEPENDENCIES</exclude>
                                     </excludes>
                                 </filter>
                             </filters>

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
   <groupId>com.github.streamshub</groupId>
   <artifactId>flink-sql</artifactId>
-  <version>0.1.1-SNAPSHOT</version>
+  <version>0.2.0-SNAPSHOT</version>
   <packaging>pom</packaging>
 
   <properties>
@@ -14,24 +14,23 @@
     <maven.compiler.release>17</maven.compiler.release>
 
     <!-- Maven plugin versions -->
-    <maven.compiler.version>3.13.0</maven.compiler.version>
+    <maven.compiler.version>3.14.0</maven.compiler.version>
     <maven.assembly.version>3.7.1</maven.assembly.version>
-    <maven.download.version>2.0.0</maven.download.version>
-    <maven.surefire.version>3.5.2</maven.surefire.version>
-    <jacoco.version>0.8.12</jacoco.version>
+    <download.maven.version>2.0.0</download.maven.version>
+    <maven.surefire.version>3.5.3</maven.surefire.version>
+    <jacoco.version>0.8.13</jacoco.version>
 
     <!-- Project dependency version -->
-    <flink.version>1.20.1</flink.version>
-    <kafka.version>3.9.0</kafka.version>
-    <slf4j.version>2.0.16</slf4j.version>
+    <flink.version>2.0.0</flink.version>
+    <slf4j.version>2.0.17</slf4j.version>
     <log4j.version>2.24.3</log4j.version>
     <fabric8.kubernetes-client.version>6.13.5</fabric8.kubernetes-client.version>
-    <flink.avro.confluent.registry.version>1.20.0</flink.avro.confluent.registry.version>
-    <flink.kafka.connector.version>3.4.0-1.20</flink.kafka.connector.version>
+    <flink.avro.confluent.registry.version>2.0.0</flink.avro.confluent.registry.version>
+    <flink.kafka.connector.version>4.0.0-2.0</flink.kafka.connector.version>
 
     <!-- Test only dependencies -->
-    <mockito.version>5.15.2</mockito.version>
-    <jupiter.version>5.11.4</jupiter.version>
+    <mockito.version>5.17.0</mockito.version>
+    <jupiter.version>5.12.2</jupiter.version>
     <!-- Sonar settings -->
     <sonar.host.url>https://sonarcloud.io</sonar.host.url>
     <sonar.organization>streamshub</sonar.organization>
@@ -51,9 +50,9 @@
           <version>${maven.compiler.version}</version>
         </plugin>
         <plugin>
-          <groupId>com.googlecode.maven-download-plugin</groupId>
+          <groupId>io.github.download-maven-plugin</groupId>
           <artifactId>download-maven-plugin</artifactId>
-          <version>${maven.download.version}</version>
+          <version>${download.maven.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
## Description

This PR updates the runner to Flink 2.0.0 as well as updating several other dependencies and versions:

- Bump the next version of the runner to 0.2.0 (rather than 0.1.1)
- Upgrade to Flink 2.0.0 
- Upgrade to Flink Connector Kafka 4.0.0-2.0
- Upgrade to the lates UBI 9 minor version (9.5)
- Upgrade to the OpenJDK 17 base image as the OpenJDK 11 image is no longer getting updates (from what I can see)
- Added some additional exclusions to the shade plugin to reduce warning noise in the maven build.
- Set `tarLongFileMode` to `posix` to reduce warning noise in the maven build.

## Type of Change

* Update 

## Testing

I have smoke tested this with the example in the repo and the interactive ETL example from the flink-sql-examples repo.

I will also run the full test suite:
```
/packit test --labels flink-all
```