### PR TITLE
Update flink version examples to v2 and operator version to 1.11.0

### DIFF
--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -40,7 +40,7 @@ metadata:
   name: standalone-etl
 spec:
   image: quay.io/streamshub/flink-sql-runner:0.1.0
-  flinkVersion: v1_20
+  flinkVersion: v2_0
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"
   serviceAccount: flink

--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -39,7 +39,7 @@ kind: FlinkDeployment
 metadata:
   name: standalone-etl
 spec:
-  image: quay.io/streamshub/flink-sql-runner:0.1.0
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
   flinkVersion: v2_0
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -8,7 +8,7 @@ The operator installs a webhook that requires CertManager to function, so this n
 
 [source, bash]
 ----
-kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.15.2/cert-manager.yaml
+kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.yaml
 ----
 [source, bash]
 ----
@@ -21,7 +21,7 @@ First add the `+helm+` repository, if you haven't already:
 
 [source, bash]
 ----
-helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.10.0/
+helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.11.0/
 ----
 
 Then install the helm chart for operator 1.10:

--- a/examples/FlinkDeployment.yaml
+++ b/examples/FlinkDeployment.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   image: quay.io/streamshub/flink-sql-runner:v0.0.1
   imagePullPolicy: Always
-  flinkVersion: v1_20
+  flinkVersion: v2_0
   flinkConfiguration:
     taskmanager.numberOfTaskSlots: "1"
   serviceAccount: flink

--- a/examples/FlinkDeployment.yaml
+++ b/examples/FlinkDeployment.yaml
@@ -3,7 +3,7 @@ kind: FlinkDeployment
 metadata:
   name: flink-deployment-example
 spec:
-  image: quay.io/streamshub/flink-sql-runner:v0.0.1
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
   imagePullPolicy: Always
   flinkVersion: v2_0
   flinkConfiguration:


### PR DESCRIPTION
## Description

Update versions of flink in examples to v2
Update flink-operator to 1.11.0


## Type of Change

Please delete options that are not relevant.

* Documentation update

