### PR TITLE
Bump assertj version harmonised java release property

### DIFF
--- a/flink-sql-runner/pom.xml
+++ b/flink-sql-runner/pom.xml
@@ -12,15 +12,15 @@
     <artifactId>flink-sql-runner</artifactId>
 
     <properties>
-        <maven.compiler.release>11</maven.compiler.release>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     </properties>
+
     <dependencyManagement>
         <dependencies>
             <dependency>
                 <groupId>org.assertj</groupId>
                 <artifactId>assertj-bom</artifactId>
-                <version>3.26.3</version>
+                <version>${assertj-bom.version}</version>
                 <scope>import</scope>
                 <type>pom</type>
             </dependency>
@@ -101,7 +101,7 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-shade-plugin</artifactId>
-                <version>3.6.0</version>
+                <version>${maven.shade.version}</version>
                 <executions>
                     <!-- Run shade goal on package phase -->
                     <execution>

--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,9 @@
     <maven.assembly.version>3.7.1</maven.assembly.version>
     <download.maven.version>2.0.0</download.maven.version>
     <maven.surefire.version>3.5.3</maven.surefire.version>
+    <maven.shade.version>3.6.0</maven.shade.version>
     <jacoco.version>0.8.13</jacoco.version>
+    <assertj-bom.version>3.27.3</assertj-bom.version>
 
     <!-- Project dependency version -->
     <flink.version>2.0.0</flink.version>


### PR DESCRIPTION
## Description

This PR bumps the `assertj` version (as per #75) and also removes the override for the release Java version in the sql-runner project so it uses the parent pom version (17).

## Type of Change

* Update (Update version or update existing automation)