### PR TITLE
Use official maven bin url for CI

### DIFF
--- a/tmt/plans/main.fmf
+++ b/tmt/plans/main.fmf
@@ -75,7 +75,7 @@ prepare:
     how: shell
     script: |
       mkdir -p /usr/share/maven /usr/share/maven/ref
-      curl -fsSL -o /tmp/apache-maven.tar.gz https://dlcdn.apache.org/maven/maven-3/3.9.9/binaries/apache-maven-3.9.9-bin.tar.gz
+      curl -fsSL -o /tmp/apache-maven.tar.gz https://repo.maven.apache.org/maven2/org/apache/maven/apache-maven/3.9.9/apache-maven-3.9.9-bin.tar.gz
       tar -xzf /tmp/apache-maven.tar.gz -C /usr/share/maven --strip-components=1
       rm -f /tmp/apache-maven.tar.gz
       ln -s /usr/share/maven/bin/mvn /usr/bin/mvn


### PR DESCRIPTION
## Description

Fix maven bin url.


## Type of Change

Please delete options that are not relevant.

* Bug fix (non-breaking change which fixes an issue)

## Testing
Packit test job with smoke subset of tests is triggered by default.
If you want to run full flink test profile please type a following comment
```
/packit test --labels flink-all
```
