### PR TITLE
Update Flink k8s operator requirement to 1.12.1 and certmanager to 1.18.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ An application to execute Flink SQL jobs.
 
 ## Building and running Flink SQL Runner
 
-_Note_: Refer to the instructions `docs/installation.adoc` to install the Flink Kubernetes Operator.
+_Note_: Refer to the instructions [`docs/installation.adoc`](docs/installation.adoc) to install the Flink Kubernetes Operator.
 
 1. Build application
     ```

--- a/docs/installation.adoc
+++ b/docs/installation.adoc
@@ -8,7 +8,7 @@ The operator installs a webhook that requires CertManager to function, so this n
 
 [source, bash]
 ----
-kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.17.2/cert-manager.yaml
+kubectl create -f https://github.com/jetstack/cert-manager/releases/download/v1.18.2/cert-manager.yaml
 ----
 [source, bash]
 ----
@@ -21,10 +21,10 @@ First add the `+helm+` repository, if you haven't already:
 
 [source, bash]
 ----
-helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.11.0/
+helm repo add flink-operator-repo https://downloads.apache.org/flink/flink-kubernetes-operator-1.12.1/
 ----
 
-Then install the helm chart for operator 1.10:
+Then install the helm chart for operator 1.12.1:
 
 [source, bash]
 ----


### PR DESCRIPTION
## Description

Update documentation to point to Flink Kubernetes Operator 1.12.1 (which contains critical bug fixes). Also update the recommended certmanager version to the latest 1.18.2. 

## Type of Change

Please delete options that are not relevant.

* Update (Update version or update existing automation)
