### PR TITLE
Add SQL parsing from env var

### DIFF
--- a/docs/deploying.adoc
+++ b/docs/deploying.adoc
@@ -25,8 +25,14 @@ In this case, it would look something like this:
 
 == Deploying a Flink SQL Query
 
-Your SQL query can be submitted via the `+spec.job.args+` field of the `+FlinkDeployment+` custom resource.
-It should be formed of a single string within an array literal (`+[ ]+`).
+Your SQL query can be submitted via either:
+
+* The `+spec.job.args+` field of the `+FlinkDeployment+` custom resource.
+* The `+SQL_STATEMENTS+` environment variable of the main `+FlinkDeployment+` container.
+
+=== `+spec.job.args+`
+
+Your SQL query should be formed of a single string within an array literal (`+[ ]+`).
 https://yaml-multiline.info/[Multi-line yaml strings] (using `+|+`,`+>+` characters) are not currently supported. 
 However, newlines, tabs, and other whitespace characters within a single string are ignored, so queries can still be well-formatted.
 See the example below for an illustration of the formatting.
@@ -75,6 +81,80 @@ spec:
           SELECT * 
           FROM orders;
         "]
+    parallelism: 1
+    upgradeMode: stateless
+----
+
+=== `+SQL_STATEMENTS+`
+
+This environment variable is useful for providing an SQL query from a `ConfigMap` or `Secret`.
+
+For example, like this:
+
+.Example SQL file
+[source,sql]
+----
+-- standalone-etl.sql
+CREATE TABLE orders (
+  order_number BIGINT,
+  price DECIMAL(32,2),
+  buyer ROW<first_name STRING,
+  last_name STRING>,
+  last_name STRING,
+  order_time TIMESTAMP(3)
+) WITH (
+  'connector' = 'datagen'
+);
+
+CREATE TABLE print_table
+WITH (
+  'connector' = 'print'
+)
+LIKE orders;
+
+INSERT INTO print_table
+  SELECT *
+  FROM orders;
+----
+
+.Example ConfigMap from SQL file
+[source,bash]
+----
+kubectl create configmap -n flink standalone-etl-sql \
+  --from-file=SQL_STATEMENTS=standalone-etl.sql
+----
+
+.Example FlinkDeployment using SQL from ConfigMap
+[source,yaml]
+----
+apiVersion: flink.apache.org/v1beta1
+kind: FlinkDeployment
+metadata:
+  name: standalone-etl
+spec:
+  image: quay.io/streamshub/flink-sql-runner:0.2.0
+  flinkVersion: v2_0
+  flinkConfiguration:
+    taskmanager.numberOfTaskSlots: "1"
+  serviceAccount: flink
+  podTemplate:
+    kind: Pod
+    spec:
+      containers:
+        - name: flink-main-container
+          envFrom:
+            - configMapRef:
+                name: standalone-etl-sql
+  jobManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  taskManager:
+    resource:
+      memory: "2048m"
+      cpu: 1
+  job:
+    jarURI: local:///opt/streamshub/flink-sql-runner.jar
     parallelism: 1
     upgradeMode: stateless
 ----

--- a/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
+++ b/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
@@ -54,7 +54,7 @@ public class SqlRunner {
         } else if (sqlFromEnvVar != null) {
             statements = parseStatements(sqlFromEnvVar);
         } else {
-            throw new Exception(String.format("Exactly 1 argument or '%s' environment variable is expected.", CUSTOM_SQL_ENV_VAR_KEY));
+            throw new IllegalArgumentException(String.format("Exactly 1 argument or '%s' environment variable is expected.", CUSTOM_SQL_ENV_VAR_KEY));
         }
 
         EnvironmentSettings settings = EnvironmentSettings

--- a/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
+++ b/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
@@ -33,6 +33,8 @@ public class SqlRunner {
 
     private static final Logger LOG = LoggerFactory.getLogger(SqlRunner.class);
 
+    private static final String CUSTOM_SQL_ENV_VAR_KEY = "CUSTOM_SQL";
+
     private static final String STATEMENT_DELIMITER = ";"; // a statement should end with `;`
     private static final String LINE_DELIMITER = "\n";
 
@@ -43,11 +45,17 @@ public class SqlRunner {
             Pattern.compile("(EXECUTE STATEMENT SET BEGIN.*?END;)", Pattern.CASE_INSENSITIVE | Pattern.DOTALL);
 
     public static void main(String[] args) throws Exception {
-        if (args.length != 1) {
-            throw new Exception("Exactly 1 argument is expected.");
-        }
+        List<String> statements;
 
-        var statements = parseStatements(args[0]);
+        String sql_from_env_var = System.getenv(CUSTOM_SQL_ENV_VAR_KEY);
+
+        if (args.length == 1) {
+            statements = parseStatements(args[0]);
+        } else if (sql_from_env_var != null) {
+            statements = parseStatements(sql_from_env_var);
+        } else {
+            throw new Exception(String.format("Exactly 1 argument or '%s' environment variable is expected.", CUSTOM_SQL_ENV_VAR_KEY));
+        }
 
         EnvironmentSettings settings = EnvironmentSettings
                 .newInstance()

--- a/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
+++ b/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
@@ -33,7 +33,7 @@ public class SqlRunner {
 
     private static final Logger LOG = LoggerFactory.getLogger(SqlRunner.class);
 
-    private static final String CUSTOM_SQL_ENV_VAR_KEY = "CUSTOM_SQL";
+    private static final String CUSTOM_SQL_ENV_VAR_KEY = "SQL_STATEMENTS";
 
     private static final String STATEMENT_DELIMITER = ";"; // a statement should end with `;`
     private static final String LINE_DELIMITER = "\n";

--- a/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
+++ b/flink-sql-runner/src/main/java/com/github/streamshub/flink/SqlRunner.java
@@ -47,12 +47,12 @@ public class SqlRunner {
     public static void main(String[] args) throws Exception {
         List<String> statements;
 
-        String sql_from_env_var = System.getenv(CUSTOM_SQL_ENV_VAR_KEY);
+        String sqlFromEnvVar = System.getenv(CUSTOM_SQL_ENV_VAR_KEY);
 
         if (args.length == 1) {
             statements = parseStatements(args[0]);
-        } else if (sql_from_env_var != null) {
-            statements = parseStatements(sql_from_env_var);
+        } else if (sqlFromEnvVar != null) {
+            statements = parseStatements(sqlFromEnvVar);
         } else {
             throw new Exception(String.format("Exactly 1 argument or '%s' environment variable is expected.", CUSTOM_SQL_ENV_VAR_KEY));
         }


### PR DESCRIPTION
## Description

Resolves #84
Testing: https://github.com/streamshub/streams-e2e/issues/151

Adds ability to parse SQL from environment variable (key is hard-coded) e.g. like this:

```sql
# recommendation-app.sql
CREATE TABLE ClickStreamTable
# ... more SQL ...
```

```bash
kubectl create configmap -n flink recommendation-app-sql \
  --from-file=SQL_STATEMENTS=recommendation-app.sql
```

```yaml
# flink-deployment.yaml
# Only relevant parts included
apiVersion: flink.apache.org/v1beta1
kind: FlinkDeployment
spec:
  image: quay.io/streamshub/flink-sql-runner:0.2.0
  podTemplate:
    kind: Pod
    spec:
      containers:
        - name: flink-main-container
          envFrom:
            - configMapRef:
                name: recommendation-app-sql
  job:
    jarURI: local:///opt/streamshub/flink-sql-runner.jar
    parallelism: 1
    upgradeMode: stateless

```

## Type of Change

* New feature (non-breaking change which adds functionality)

## Testing
Packit test job with smoke subset of tests is triggered by default.
If you want to run full flink test profile please type a following comment
```
/packit test --labels flink-all
```
