### PR TITLE
Update to Flink Kafka Connector 4.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -29,7 +29,7 @@
     <log4j.version>2.25.1</log4j.version>
     <fabric8.kubernetes-client.version>7.3.1</fabric8.kubernetes-client.version>
     <flink.avro.confluent.registry.version>2.0.0</flink.avro.confluent.registry.version>
-    <flink.kafka.connector.version>4.0.0-2.0</flink.kafka.connector.version>
+    <flink.kafka.connector.version>4.0.1-2.0</flink.kafka.connector.version>
 
     <!-- Test only dependencies -->
     <mockito.version>5.18.0</mockito.version>


### PR DESCRIPTION
## Description

Bump the Flink Kafka Connector to 4.0.1 which uses Kafka client 3.9.1.

## Type of Change

* Update 

## Testing

Packit test job with smoke subset of tests is triggered by default.
If you want to run full flink test profile please type a following comment
```
/packit test --labels flink-all
```
