### PR TITLE
Add TOC to docs

### DIFF
--- a/docs/index.adoc
+++ b/docs/index.adoc
@@ -1,3 +1,5 @@
+:toc:
+
 = Flink SQL Runner
 
 include::overview.adoc[leveloffset=1]


### PR DESCRIPTION
## Description

Add [TOC](https://docs.asciidoctor.org/asciidoc/latest/toc/) to docs. Need to add this attribute for TOC to show up on StreamsHub website.

## Type of Change

* Documentation update
