### PR TITLE
Update `strimzi.kafka-oauth-client` to `0.17.0`

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,7 +30,7 @@
     <fabric8.kubernetes-client.version>7.3.1</fabric8.kubernetes-client.version>
     <flink.avro.confluent.registry.version>2.0.0</flink.avro.confluent.registry.version>
     <flink.kafka.connector.version>4.0.1-2.0</flink.kafka.connector.version>
-    <strimzi.kafka-oauth-client.version>0.16.2</strimzi.kafka-oauth-client.version>
+    <strimzi.kafka-oauth-client.version>0.17.0</strimzi.kafka-oauth-client.version>
 
     <!-- Test only dependencies -->
     <mockito.version>5.19.0</mockito.version>


### PR DESCRIPTION
## Description

Update `strimzi.kafka-oauth-client` to `0.17.0`.

## Type of Change

* Update (Update version or update existing automation)

## Testing
Packit test job with smoke subset of tests is triggered by default.
If you want to run full flink test profile please type a following comment
```
/packit test --labels flink-all
```
